### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,19 @@ all: build_debug
 
 build_debug: box2d premake
 	.build/premake5 gmake --cc=clang
-	make -C .build config=debug_x86_64
+	make -C .build config=debug_x86_64 -j $(($(grep -c ^processor /proc/cpuinfo)/2))
 	test -d bin || mkdir bin
 	cp .build/bin/x86_64/Debug/carnage3d bin/carnage3d-debug
 
 build_release: box2d premake
 	.build/premake5 gmake --cc=clang
-	make -C .build config=release_x86_64
+	make -C .build config=release_x86_64 -j $(($(grep -c ^processor /proc/cpuinfo)/2))
 	test -d bin || mkdir bin
 	cp .build/bin/x86_64/Release/carnage3d bin/carnage3d-release
+
+clean:
+	.build/premake5 gmake --cc=clang
+	make -C .build clean
 
 run:
 	bin/carnage3d-release


### PR DESCRIPTION
This PR includes:
1. `make clean` to remove all compiled objects.
2. `make` will use `-j N` by default, where `N` is half of the available cores.