### PR TITLE
Enable address and undefined sanitizers

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -3,7 +3,8 @@ workspace "carnage3d"
    configurations { "Debug", "Release" }
    cppdialect 'C++17'
 
-buildoptions { "-Wno-switch", "-fsanitize=address", "-fsanitize=undefined" }
+configuration { "linux", "gmake" }
+   buildoptions { "-Wno-switch", "-fsanitize=address", "-fsanitize=undefined" }
    linkoptions { "-fsanitize=address", "-fsanitize=undefined" }
 
 filter 'system:linux'

--- a/premake5.lua
+++ b/premake5.lua
@@ -3,8 +3,8 @@ workspace "carnage3d"
    configurations { "Debug", "Release" }
    cppdialect 'C++17'
 
-configuration { "linux", "gmake" }
-  buildoptions { "-Wno-switch" }
+buildoptions { "-Wno-switch", "-fsanitize=address", "-fsanitize=undefined" }
+   linkoptions { "-fsanitize=address", "-fsanitize=undefined" }
 
 filter 'system:linux'
    platforms { 'x86_64' }


### PR DESCRIPTION
Sanitizers are a great tool that can catch undefined behavior in C/C++ compiled code such as memory corruption bugs (buffer overflows or accesses to a dangling pointer). They are [even available](https://devblogs.microsoft.com/cppblog/addresssanitizer-asan-for-windows-with-msvc/) in Windows!

Right now, it detects 3 potential issues:

```
../src/stb_sprintf.h:1187:13: runtime error: store to misaligned address 0x7ffe0bcc52a5 for type 'unsigned int', which requires 4 byte alignment
0x7ffe0bcc52a5: note: pointer points here
 61 74 61 2f 7f 00 00  e0 67 9f 46 57 55 00 00  e8 53 cc 0b fe 7f 00 00  40 53 cc 0b fe 7f 00 00  50
             ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/stb_sprintf.h:1187:13 in 
../src/stb_sprintf.h:335:13: runtime error: store to misaligned address 0x5557482a057b for type 'unsigned int', which requires 4 byte alignment
0x5557482a057b: note: pointer points here
 78  37 36 38 20 70 72 6f 66  69 6c 65 29 00 53 4d 65  73 61 20 63 6c 6f 63 6b  5f 67 65 74 74 69 6d
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/stb_sprintf.h:335:13 in 
../src/stb_sprintf.h:1187:13: runtime error: load of misaligned address 0x7f71220e3a0e for type 'unsigned int', which requires 4 byte alignment
0x7f71220e3a0e: note: pointer points here
 6c 65 72 00 31 2e  35 30 20 4e 56 49 44 49  41 20 76 69 61 20 43 67  20 63 6f 6d 70 69 6c 65  72 00
```

as well as a few memory leaks when the Carnage3D exits:

```
=================================================================
==11790==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 6280 byte(s) in 3 object(s) allocated from:
    #0 0x555746e1a4d1 in calloc (/home/g/Games/carnage3d/bin/carnage3d-debug+0x4394d1)
    #1 0x7f7121ae5995  (/usr/lib/libnvidia-glcore.so.435.21+0xe39995)

Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x555746e1a6a2 in realloc (/home/g/Games/carnage3d/bin/carnage3d-debug+0x4396a2)
    #1 0x7f7121ae528f  (/usr/lib/libnvidia-glcore.so.435.21+0xe3928f)

Indirect leak of 72672 byte(s) in 224 object(s) allocated from:
    #0 0x555746e1a4d1 in calloc (/home/g/Games/carnage3d/bin/carnage3d-debug+0x4394d1)
    #1 0x7f7121ae5995  (/usr/lib/libnvidia-glcore.so.435.21+0xe39995)

Indirect leak of 2515 byte(s) in 179 object(s) allocated from:
    #0 0x555746e1a319 in malloc (/home/g/Games/carnage3d/bin/carnage3d-debug+0x439319)
    #1 0x7f7121ae5b5b  (/usr/lib/libnvidia-glcore.so.435.21+0xe39b5b)

Indirect leak of 752 byte(s) in 6 object(s) allocated from:
    #0 0x555746e1a6a2 in realloc (/home/g/Games/carnage3d/bin/carnage3d-debug+0x4396a2)
    #1 0x7f7121ae528f  (/usr/lib/libnvidia-glcore.so.435.21+0xe3928f)
```