### PR TITLE
Fix compilation error on Linux

### DIFF
--- a/src/AiCharacterController.cpp
+++ b/src/AiCharacterController.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "AICharacterController.h"
+#include "AiCharacterController.h"
 
 void AICharacterController::UpdateFrame(Pedestrian* pedestrian)
 {


### PR DESCRIPTION
A case sensitivity issue:
```
../src/AiCharacterController.cpp:2:10: fatal error: 'AICharacterController.h' file not found
#include "AICharacterController.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~
```