### PR TITLE
Prioritise system installed premake5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
 CPUS := $(shell nproc)
+PREMAKE_BIN := $(shell which premake5)
+ifeq (, $(PREMAKE_BIN))
+PREMAKE_BIN = .build/premake5
+endif
 
 all: build_release
 	true
 
 build_sanitize: box2d premake
-	.build/premake5 gmake --cc=clang --sanitize
+	$(PREMAKE_BIN) gmake --cc=clang --sanitize
 	make -C .build config=debug_x86_64 -j$(CPUS)
 	test -d bin || mkdir bin
 	cp .build/bin/x86_64/Debug/carnage3d bin/carnage3d-debug
 
 build_debug: box2d premake
-	.build/premake5 gmake --cc=clang
+	$(PREMAKE_BIN) gmake --cc=clang
 	make -C .build config=debug_x86_64 -j$(CPUS)
 	test -d bin || mkdir bin
 	cp .build/bin/x86_64/Debug/carnage3d bin/carnage3d-debug
 
 build_release: box2d premake
-	.build/premake5 gmake --cc=clang
+	$(PREMAKE_BIN) gmake --cc=clang
 	make -C .build config=release_x86_64 -j$(CPUS)
 	test -d bin || mkdir bin
 	cp .build/bin/x86_64/Release/carnage3d bin/carnage3d-release
@@ -28,7 +32,7 @@ get_demoversion:
 	unzip gamedata/demoversions/gtaects.zip -d gamedata/demoversions
 
 clean:
-	.build/premake5 gmake --cc=clang
+	$(PREMAKE_BIN) gmake --cc=clang
 	rm -rf third_party/Box2D/build
 	make -C .build clean
 
@@ -42,7 +46,7 @@ builddir:
 	test -d .build || mkdir .build
 
 premake: builddir
-	test -e .build/premake5 || (cd .build && \
+	test -e $(PREMAKE_BIN) || (cd .build && \
 	wget https://github.com/premake/premake-core/releases/download/v5.0.0-beta1/premake-5.0.0-beta1-linux.tar.gz && \
 	tar xzf premake-5.0.0-beta1-linux.tar.gz && \
 	rm premake-5.0.0-beta1-linux.tar.gz)


### PR DESCRIPTION
Closes #53. @kattjevfel, can you verify it works for you?

If the system-wide premake5 is not available, the project one will be used & downloaded.